### PR TITLE
Migrates new items and machines in det rework to new attack chain

### DIFF
--- a/code/modules/detective_work/evidence.dm
+++ b/code/modules/detective_work/evidence.dm
@@ -233,10 +233,10 @@
 	if(user.a_intent != INTENT_HARM)
 		return ..()
 
-	if(can_take_sample(user, A))
-		take_sample(user,A)
+	if(can_take_sample(user, target))
+		take_sample(user, target)
 	else
-		to_chat(user, "<span class='warning'>You cannot find [evidence_type] on [A].</span>")
+		to_chat(user, "<span class='warning'>You cannot find [evidence_type] on [target].</span>")
 	return ITEM_INTERACT_COMPLETE
 
 /obj/item/forensics/sample_kit/MouseDrop(atom/over)

--- a/code/modules/detective_work/evidence.dm
+++ b/code/modules/detective_work/evidence.dm
@@ -84,6 +84,7 @@
 /obj/item/forensics
 	icon = 'icons/obj/forensics/forensics.dmi'
 	w_class = WEIGHT_CLASS_TINY
+	new_attack_chain = TRUE
 
 /obj/item/sample
 	name = "\improper Forensic sample"
@@ -228,19 +229,19 @@
 	var/obj/item/sample/S = new evidence_path(get_turf(user), supplied)
 	to_chat(user, "<span class='notice'>You move [S.evidence.len] [S.evidence.len > 1 ? "[evidence_type]" : "[evidence_type]"] [S].</span>")
 
-/obj/item/forensics/sample_kit/afterattack__legacy__attackchain(atom/A, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/forensics/sample_kit/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(user.a_intent != INTENT_HARM)
+		return ..()
+
 	if(can_take_sample(user, A))
 		take_sample(user,A)
-		return TRUE
-
-	to_chat(user, "<span class='warning'>You cannot find [evidence_type] on [A].</span>")
-	return ..()
+	else
+		to_chat(user, "<span class='warning'>You cannot find [evidence_type] on [A].</span>")
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/forensics/sample_kit/MouseDrop(atom/over)
 	if(ismob(src.loc))
-		afterattack__legacy__attackchain(over, usr, TRUE)
+		interact_with_atom(over, usr)
 
 /obj/item/forensics/sample_kit/powder
 	name = "fingerprint Powder"

--- a/code/modules/detective_work/forensic_machines.dm
+++ b/code/modules/detective_work/forensic_machines.dm
@@ -73,11 +73,11 @@
 		to_chat(user, "<span class='warning'>There is already a test tube inside the scanner.</span>")
 		return ITEM_INTERACT_COMPLETE
 
-	if(istype(W, /obj/item/forensics/swab))
-		to_chat(user, "<span class='notice'>You insert [W] into [src].</span>")
-		user.unequip(W)
-		W.forceMove(src)
-		swab = W
+	if(istype(used, /obj/item/forensics/swab))
+		to_chat(user, "<span class='notice'>You insert [used] into [src].</span>")
+		user.unequip(used)
+		used.forceMove(src)
+		swab = used
 		update_icon()
 	else
 		to_chat(user, "<span class='notice'>This is not a compatible sample!</span>")
@@ -199,12 +199,12 @@
 		to_chat(user, "<span class='warning'>There is already a sample in the microscope!</span>")
 		return ITEM_INTERACT_COMPLETE
 
-	if(istype(W, /obj/item/forensics/swab)|| istype(W, /obj/item/sample/fibers) || istype(W, /obj/item/sample/print))
+	if(istype(used, /obj/item/forensics/swab)|| istype(used, /obj/item/sample/fibers) || istype(used, /obj/item/sample/print))
 		add_fingerprint(user)
-		to_chat(user, "<span class='notice'>You inserted [W] into the microscope.</span>")
-		user.unequip(W)
-		W.forceMove(src)
-		sample = W
+		to_chat(user, "<span class='notice'>You inserted [used] into the microscope.</span>")
+		user.unequip(used)
+		used.forceMove(src)
+		sample = used
 		update_appearance(UPDATE_ICON_STATE)
 	return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/detective_work/forensic_machines.dm
+++ b/code/modules/detective_work/forensic_machines.dm
@@ -45,7 +45,7 @@
 	icon_state = "dnaopen"
 	anchored = TRUE
 	density = TRUE
-	new_attack_chain = FALSE
+	new_attack_chain = TRUE
 
 	var/obj/item/forensics/swab = null
 	///is currently scanning
@@ -68,10 +68,10 @@
 	. += "<span class='notice'><b>Click while holding a sample</b> to insert a sample.</span>"
 	. += "<span class='notice'><b>Click with an empty hand</b> to operate.</span>"
 
-/obj/machinery/dnaforensics/attackby__legacy__attackchain(obj/item/W as obj, mob/user as mob)
+/obj/machinery/dnaforensics/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(swab)
 		to_chat(user, "<span class='warning'>There is already a test tube inside the scanner.</span>")
-		return
+		return ITEM_INTERACT_COMPLETE
 
 	if(istype(W, /obj/item/forensics/swab))
 		to_chat(user, "<span class='notice'>You insert [W] into [src].</span>")
@@ -79,10 +79,9 @@
 		W.forceMove(src)
 		swab = W
 		update_icon()
-		return
 	else
 		to_chat(user, "<span class='notice'>This is not a compatible sample!</span>")
-		return
+	return ITEM_INTERACT_COMPLETE
 
 /obj/machinery/dnaforensics/attack_hand(mob/user)
 
@@ -181,6 +180,7 @@
 	var/obj/item/sample = null
 	var/report_num = 0
 	var/fingerprint_complete = 6
+	new_attack_chain = TRUE
 
 /obj/machinery/microscope/Initialize(mapload)
 	. = ..()
@@ -194,10 +194,10 @@
 	. = ..()
 	. += "<span class='notice'>You can <b>Alt-Click</b> to eject the current sample. <b>Click while holding a sample</b> to insert a sample. <b>Click with an empty hand</b> to operate.</span>"
 
-/obj/machinery/microscope/attackby__legacy__attackchain(obj/item/W as obj, mob/user as mob)
+/obj/machinery/microscope/item_interaction(mob/living/user, obj/item/used, list/modifiers)
 	if(sample)
 		to_chat(user, "<span class='warning'>There is already a sample in the microscope!</span>")
-		return
+		return ITEM_INTERACT_COMPLETE
 
 	if(istype(W, /obj/item/forensics/swab)|| istype(W, /obj/item/sample/fibers) || istype(W, /obj/item/sample/print))
 		add_fingerprint(user)
@@ -206,8 +206,7 @@
 		W.forceMove(src)
 		sample = W
 		update_appearance(UPDATE_ICON_STATE)
-		return
-	..()
+	return ITEM_INTERACT_COMPLETE
 
 /obj/machinery/microscope/attack_hand(mob/user)
 

--- a/code/modules/detective_work/swabs.dm
+++ b/code/modules/detective_work/swabs.dm
@@ -36,25 +36,25 @@
 		var/list/found_blood = list()
 
 		// This is utterly hateful, yes, but so is blood_DNA. - Chuga
-		if(issimulatedturf(A))
-			for(var/obj/effect/decal/cleanable/C in A.contents)
+		if(issimulatedturf(target))
+			for(var/obj/effect/decal/cleanable/C in target.contents)
 				if(istype(C, /obj/effect/decal/cleanable/blood) || istype(C, /obj/effect/decal/cleanable/trail_holder))
 					found_blood |= C.blood_DNA
-		else if(isliving(A))
-			var/mob/living/L = A
+		else if(isliving(target))
+			var/mob/living/L = target
 			found_blood |= L.get_blood_dna_list()
 		else
-			if(A.blood_DNA)
-				found_blood |= A.blood_DNA
+			if(target.blood_DNA)
+				found_blood |= target.blood_DNA
 
 		if(length(found_blood))
 			choices |= "Blood"
-		if(istype(A, /obj/item/clothing/gloves))
+		if(istype(target, /obj/item/clothing/gloves))
 			choices |= "Gunpowder particles"
 
 		var/choice
 		if(!length(choices))
-			to_chat(user, "<span class='warning'>There is no evidence on [A].</span>")
+			to_chat(user, "<span class='warning'>There is no evidence on [target].</span>")
 			inuse = FALSE
 			return ITEM_INTERACT_COMPLETE
 		else if(length(choices) == 1)
@@ -74,9 +74,9 @@
 			sample_type = "blood"
 
 		else if(choice == "Gunpowder particles")
-			var/obj/item/clothing/B = A
+			var/obj/item/clothing/B = target
 			if(!istype(B) || !B.gunshot_residue)
-				to_chat(user, "<span class='warning'>There is not a hint of gunpowder on [A].</span>")
+				to_chat(user, "<span class='warning'>There is not a hint of gunpowder on [target].</span>")
 				inuse = FALSE
 				return ITEM_INTERACT_COMPLETE
 			target_gsr = B.gunshot_residue
@@ -84,17 +84,17 @@
 
 		if(sample_type)
 			user.visible_message(
-				"<span class='notice'>[user] takes a swab from [A] for analysis.</span>",
-				"<span class='notice'>You take a swab from [A] for analysis.</span>")
+				"<span class='notice'>[user] takes a swab from [target] for analysis.</span>",
+				"<span class='notice'>You take a swab from [target] for analysis.</span>")
 			if(!dispenser)
 				dna = target_dna
 				gsr = target_gsr
-				set_used(sample_type, A)
+				set_used(sample_type, target)
 			else
 				var/obj/item/forensics/swab/S = new(get_turf(user))
 				S.dna = target_dna
 				S.gsr = target_gsr
-				S.set_used(sample_type, A)
+				S.set_used(sample_type, target)
 	inuse = FALSE
 	return ITEM_INTERACT_COMPLETE
 

--- a/code/modules/detective_work/swabs.dm
+++ b/code/modules/detective_work/swabs.dm
@@ -20,17 +20,13 @@
 /obj/item/forensics/swab/proc/is_used()
 	return used
 
-/obj/item/forensics/swab/pre_attack(atom/A, mob/living/user, params)
-	. = ..()
-	return A.attackby__legacy__attackchain(src, user, params)
-
-/obj/item/forensics/swab/afterattack__legacy__attackchain(atom/A, mob/user, proximity)
-	if(istype(A, /obj/machinery/microscope))
-		return
+/obj/item/forensics/swab/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(isstorage(target)) // Storage handling. Maybe add an intent check?
+		return ..()
 
 	if(is_used())
 		to_chat(user, "<span class='warning'>This sample kit is already used.</span>")
-		return
+		return ITEM_INTERACT_COMPLETE
 
 	add_fingerprint(user)
 	inuse = TRUE
@@ -60,7 +56,7 @@
 		if(!length(choices))
 			to_chat(user, "<span class='warning'>There is no evidence on [A].</span>")
 			inuse = FALSE
-			return
+			return ITEM_INTERACT_COMPLETE
 		else if(length(choices) == 1)
 			choice = choices[1]
 		else
@@ -68,7 +64,7 @@
 
 		if(!choice)
 			inuse = FALSE
-			return
+			return ITEM_INTERACT_COMPLETE
 
 		var/sample_type
 		var/target_dna
@@ -82,7 +78,7 @@
 			if(!istype(B) || !B.gunshot_residue)
 				to_chat(user, "<span class='warning'>There is not a hint of gunpowder on [A].</span>")
 				inuse = FALSE
-				return
+				return ITEM_INTERACT_COMPLETE
 			target_gsr = B.gunshot_residue
 			sample_type = "powder"
 
@@ -99,7 +95,8 @@
 				S.dna = target_dna
 				S.gsr = target_gsr
 				S.set_used(sample_type, A)
-		inuse = FALSE
+	inuse = FALSE
+	return ITEM_INTERACT_COMPLETE
 
 /obj/item/forensics/swab/proc/set_used(sample_str, atom/source)
 	name = ("[initial(name)] ([sample_str] - [source])")


### PR DESCRIPTION
## What Does This PR Do
Migrated the machinery and newly introduced items. Fixes swabs potentially bricking themselves if you interrupt the do_after, makes the sample kit require harm intent to sample. That could be extended to swabs too (idk if bags get bloodied), since wed need an exception on when NOT to continue the attack chain and swab it.
## Testing
Havent yet, will do later.
## Declaration
- [x] I confirm that I either do not require [pre-approval](https://github.com/ParadiseSS13/Paradise/blob/master/docs/CODE_OF_CONDUCT.md#types-of-changes-that-need-approval) for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
## Changelog
:cl:
fix: swabs wont brick when their do_after is interrupted
tweak: sample kit requires harm intent to sample
/:cl: